### PR TITLE
Relax base bounds to allow GHC 9.12

### DIFF
--- a/avl-static.cabal
+++ b/avl-static.cabal
@@ -19,7 +19,7 @@ library
   exposed-modules:     Data.Tree.AVL.Static, Data.Tree.AVL.Static.Internal
   -- other-modules:       
   other-extensions:    GADTs, ExistentialQuantification, DataKinds, InstanceSigs, StandaloneDeriving, KindSignatures, ScopedTypeVariables
-  build-depends:       base >=4.6 && <4.7
+  build-depends:       base >=4.6 && <4.22
   -- hs-source-dirs:      
   default-language:    Haskell2010
 


### PR DESCRIPTION
Tested with
```
cabal test -w ghc-9.12
```
It still works fine :)